### PR TITLE
docs: 同步 README 至 v1.4.0 行为

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 > WorkBuddy 切换账号后对话记录不见了？一键恢复。
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Platform: macOS](https://img.shields.io/badge/Platform-macOS-blue.svg)](https://www.apple.com/macos)
+[![Platform: macOS | Windows | Linux](https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-blue.svg)](https://github.com/xiaoliuzhuan666/workbuddy-account-migrate)
 [![Python 3.8+](https://img.shields.io/badge/Python-3.8+-green.svg)](https://www.python.org/)
-[![Version 1.3.0](https://img.shields.io/badge/Version-1.3.0-brightgreen.svg)](https://github.com/xiaoliuzhuan666/workbuddy-account-migrate)
+[![Version 1.4.0](https://img.shields.io/badge/Version-1.4.0-brightgreen.svg)](https://github.com/xiaoliuzhuan666/workbuddy-account-migrate)
 
 **[English](#english) | [中文](#chinese)**
 
@@ -45,13 +45,14 @@ WorkBuddy 切换账号 / 重新登录 / 换了腾讯云身份后，**之前的�
 
 | 特性 | 说明 |
 |:---|:---|
-| ✅ 交互式向导 | 运行即用，自动诊断、列出账号、输入序号选择，无需知道 user_id |
+| ✅ 交互式向导 | 运行即用，列出所有账号，手动选择目标/源账号，无需知道 user_id |
+| ✅ 跨平台路径适配 | v1.4：storage.json 路径自动适配 macOS / Windows / Linux |
 | ✅ Session 对话记录迁移 | 修改 SQLite 数据库中的 `user_id` 字段，对话记录全部回归 |
 | ✅ Memory 长期记忆合并 | 追加式去重合并，不会丢失当前账号已有记忆 |
 | ✅ Connector MCP 连接器合并 | JSON 深度合并，目标账号已有配置保留不动 |
 | ✅ 自动备份 + 回滚 | 迁移前自动备份数据库、记忆、连接器，支持一键回滚 |
 | ✅ WAL 安全处理 | 迁移前后执行 SQLite checkpoint，确保数据持久化 |
-| ✅ 多源 user_id 验证 | v1.3：从 DB 最新 session 和 storage.json 交叉验证，避免过时 ID 导致迁移失败 |
+| ✅ 登录态权威识别 | v1.4：以 storage.json 为当前账号权威来源，DB 按 session 数最多辅助验证 |
 | ✅ 迁移结果验证 | v1.3：UPDATE 后验证源 user_id 归零，确认迁移成功 |
 | ✅ 零依赖 | 仅需 Python 3.8+，无第三方包 |
 
@@ -70,16 +71,14 @@ python3 scripts/migrate.py
 WorkBuddy 账号迁移向导
 ======================================================================
 
-当前登录: abc12345-6789-...
+请选择迁移方向：先选【目标账号】（接收数据），再选【源账号】（被迁移）
 
-发现以下可迁移的账号：
+  序号   user_id                                  Sessions     Memory   Connectors
+  ------------------------------------------------------------------------
+  1      abc12345-6789-...                              18     13.0KB  17mcp/6conn
+  2      def67890-1234-...                               7      5.1KB  17mcp/4conn
 
-  序号   Sessions     Memory   Connectors
-  ----------------------------------------
-  1           7      5.1KB  17mcp/4conn
-  2          18     13.0KB  17mcp/6conn
-
-请输入要迁移的账号序号（输入 q 取消）: 2
+请选择【目标账号】（接收数据的账号，输入序号）: 1
 ```
 
 输入序号即可，全程不需要知道 user_id。
@@ -92,6 +91,9 @@ python3 scripts/migrate.py --diagnose
 
 # 指定源账号迁移（高级用户）
 python3 scripts/migrate.py --source <USER_ID>
+
+# 显式指定目标账号（不依赖当前登录态推断，v1.4 新增）
+python3 scripts/migrate.py --source <USER_ID> --target <USER_ID>
 
 # 回滚到指定备份
 python3 scripts/migrate.py --rollback <TAG>
@@ -110,7 +112,7 @@ python3 scripts/migrate.py --rollback <TAG>
 
 ### 工作原理
 
-**Step 1：自动诊断** — 从数据库、Memory 文件、Connector 目录三个来源自动发现所有账号。当前登录账号通过**多源交叉验证**自动获取（DB 最新 session user_id + storage.json 的 genie.userId，不一致时优先使用 DB 值并发出警告）。
+**Step 1：自动诊断** — 从数据库、Memory 文件、Connector 目录三个来源自动发现所有账号。当前登录账号以 **storage.json 的 genie.userId 为权威来源**，DB 中 session 数最多的 user_id 作为辅助验证，不一致时以 storage.json 为准并发出警告（v1.4 起；此前用"最新 session"推断，旧账号的最后一条 session 可能比当前账号更新，导致误判）。
 
 **Step 2：安全备份** — 迁移前自动备份到 `~/.workbuddy/migrate_backups/{timestamp}_{uid}/`
 
@@ -125,8 +127,8 @@ python3 scripts/migrate.py --rollback <TAG>
 | 平台 | 状态 |
 |:---|:---|
 | WorkBuddy (macOS) | ✅ 已测试 |
-| WorkBuddy (Windows) | ⚠️ 路径需适配（`%APPDATA%`），欢迎 PR |
-| WorkBuddy (Linux) | ⚠️ 路径需适配（`~/.config`），欢迎 PR |
+| WorkBuddy (Windows) | ✅ 已适配（v1.4，`%APPDATA%` 路径，欢迎实测反馈） |
+| WorkBuddy (Linux) | ✅ 已适配（v1.4，`XDG_CONFIG_HOME` 路径，欢迎实测反馈） |
 | CodeBuddy CLI | ❌ 不适用（见下方说明） |
 
 **为什么不支持 CodeBuddy CLI？** CodeBuddy CLI 的记忆按项目维度隔离（`~/.codebuddy/memories/{project-id}/`），对话记录按 `{sessionId}.jsonl` 独立文件存储，不依赖 `user_id` 过滤，**不存在账号切换后数据丢失的问题**。如果你是 CodeBuddy 用户遇到类似问题，欢迎提 Issue。
@@ -170,7 +172,7 @@ A: Session 的 `user_id` 被改为新账号，所以在旧账号的 UI 下不可
 
 **Q: 支持双向迁移吗？**
 
-A: 支持。从账号 A 迁到 B 后，也可以再从 B 迁回 A。但注意 Memory 是追加合并，多次迁移可能产生重复内容。
+A: 支持。从 B 迁到 A 后，可以登录 B 再执行 `--source <A的user_id>`，或者用 `--target` 直接指定目标账号、无需切换登录。Memory 按行去重、Connector 按 key 合并，反向迁移不会产生重复内容。注意：反向迁移会把 A 名下**所有** session 一起迁走（包括 A 原有的）；如果只是想撤销上一次迁移，用 `--rollback` 回滚更干净。
 
 **Q: 支持 CodeBuddy CLI 吗？**
 
@@ -178,7 +180,7 @@ A: 暂不支持。CodeBuddy CLI 不存在账号切换数据丢失的问题。详
 
 **Q: Windows / Linux 可以用吗？**
 
-A: 脚本中的 `STORAGE_JSON` 路径目前硬编码为 macOS 路径。Windows 和 Linux 需要适配路径，欢迎提 PR。
+A: 可以。v1.4 起 storage.json 路径已按平台自动适配（macOS `~/Library/Application Support/...`、Windows `%APPDATA%`、Linux `XDG_CONFIG_HOME`）。
 
 ### 项目结构
 
@@ -198,9 +200,19 @@ workbuddy-account-migrate/
 
 - Bug 报告 / 功能请求 → [Issues](https://github.com/xiaoliuzhuan666/workbuddy-account-migrate/issues)
 - 代码贡献 → 提交 PR，请确保无硬编码的 user_id 或 Token
-- 平台适配（Windows/Linux）→ 欢迎 PR
+- Windows / Linux 实测反馈 → 欢迎 Issue
 
 ### 更新日志
+
+#### v1.4.0 (2026-08-06)
+
+**跨平台支持 + 当前账号识别修复**（感谢 [@yuren238](https://github.com/yuren238)，PR #1）
+
+- **跨平台**：storage.json 路径自动适配 macOS / Windows / Linux，不再硬编码 macOS 路径
+- **Bug 修复**：当前账号识别改为以 storage.json 为权威来源，DB 按 session 数最多做辅助验证。此前用"最新 session"推断，旧账号的最后一条 session 可能比当前账号更新，导致误把旧账号当成当前账号
+- **新增**：`--target` 参数，可手动指定目标账号，无需切换登录
+- **改进**：交互式向导改为手动选择目标/源账号，避免自动推断错误
+- **Bug 修复**：Windows GBK 编码终端下 emoji 输出导致 UnicodeEncodeError 崩溃
 
 #### v1.3.0 (2026-05-26)
 
@@ -258,19 +270,30 @@ Skills, Automations, Settings are global (no user_id) — no migration needed.
 
 ### Features
 
-- 🧙 Interactive wizard (no user_id needed)
+- 🧙 Interactive wizard (pick target & source accounts by number, no user_id needed)
+- 🖥️ Cross-platform: storage.json path auto-detected for macOS / Windows / Linux (v1.4)
 - 🔒 Safe: append-only memory, deep-merge connectors, WAL checkpoint before & after
-- 🔍 Multi-source user_id validation (DB + storage.json cross-check)
+- 🔍 Authoritative login detection: storage.json first, DB session-count as cross-check (v1.4)
 - ✅ Post-migration verification (source user_id must be zero)
 - 🪶 Zero dependencies (Python 3.8+ only)
 
 ### Compatibility
 
 - ✅ WorkBuddy macOS (tested)
-- ⚠️ Windows/Linux (path adaptation needed, PRs welcome)
+- ✅ WorkBuddy Windows / Linux (paths adapted in v1.4, feedback welcome)
 - ❌ CodeBuddy CLI (not needed — it uses project-level isolation, not user-level)
 
 ### Changelog
+
+#### v1.4.0 (2026-08-06)
+
+**Cross-platform support + current-account detection fix** (thanks [@yuren238](https://github.com/yuren238), PR #1)
+
+- **Cross-platform**: storage.json path auto-adapts to macOS / Windows / Linux (no more hardcoded macOS path)
+- **Bug fix**: current account is now detected from storage.json as the authoritative source, with the DB's most-frequent user_id as a cross-check. Previously the "latest session" heuristic could misidentify a stale old account as the current one
+- **New**: `--target` flag to explicitly set the target account without switching logins
+- **Improved**: interactive wizard now asks for target and source accounts explicitly, avoiding auto-inference errors
+- **Bug fix**: emoji output no longer crashes on Windows GBK/CP936 terminals (UnicodeEncodeError)
 
 #### v1.3.0 (2026-05-26)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: 账号迁移工具
 description: WorkBuddy 账号切换后一键同步数据，将旧账号的 Session 历史、Memory 记忆、Connector 配置迁移到当前账号。触发关键词：切账号、迁移、同步数据、账号切换、数据丢失、记录没了。
-version: 1.3.0
+version: 1.4.0
 agent_created: true
 ---
 


### PR DESCRIPTION
## 背景

PR #1 合并后，README 多处描述与实际行为不符，本 PR 将文档同步至 v1.4.0。

## 改动内容

**过时描述修正：**
- 平台徽章：macOS → macOS | Windows | Linux；版本徽章：1.3.0 → 1.4.0
- 「多源 user_id 验证（优先使用 DB 值）」→「登录态权威识别（storage.json 为准，DB 按 session 数辅助验证）」
- 工作原理 Step 1：同步上述识别逻辑变更
- 兼容性表：Windows / Linux 由「⚠️ 需适配」改为「✅ 已适配（v1.4）」
- FAQ「Windows / Linux 可以用吗」：路径硬编码的描述已过时，改为已自动适配
- FAQ「支持双向迁移吗」：补充 `--target` 用法与 `--rollback` 建议（呼应 issue #2 的解答）

**新增内容：**
- 快速开始：`--target` 用法示例
- 快速开始：交互式向导输出示例更新为 v1.4 的目标/源选择流程
- 中英更新日志：新增 v1.4.0 条目（致谢 @yuren238 的 PR #1）
- `SKILL.md` frontmatter 版本号同步至 1.4.0

仅文档改动，不涉及代码。